### PR TITLE
allow all url protocols in social links

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -74,7 +74,7 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
     alipay = "/path/to/your/alipay-qr-code.png"           # 支付宝二维码
 
   [params.social]                                         # 社交链接
-    a-email = "your@email.com"
+    a-email = "mailto:your@email.com"
     b-stack-overflow = "http://localhost:1313"
     c-twitter = "http://localhost:1313"
     d-facebook = "http://localhost:1313"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,11 +2,7 @@
   {{- range $name, $path := .Site.Params.social }}
     {{- if $path }}
       {{- $realName := slicestr $name 2 }}
-      {{- if eq $realName "email" }}
-        <a href="mailto:{{ $path }}" class="iconfont icon-{{ $realName }}" title="{{ $realName }}"></a>
-      {{- else }}
-        <a href="{{ $path }}" class="iconfont icon-{{ $realName }}" title="{{ $realName }}"></a>
-      {{- end }}
+      <a href="{{ $path | safeURL }}" class="iconfont icon-{{ $realName }}" title="{{ $realName }}"></a>
     {{- end }}
   {{- end }}
   <a href="{{ .Site.RSSLink }}" type="application/rss+xml" class="iconfont icon-rss" title="rss"></a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,7 +6,7 @@
   <ul id="menu" class="menu">
     {{ range .Site.Menus.main -}}
       <li class="menu-item">
-        <a class="menu-item-link" href="{{ .URL }}">{{ .Name }}</a>
+        <a class="menu-item-link" href="{{ .URL | safeURL }}">{{ .Name }}</a>
       </li>
     {{- end }}
   </ul>

--- a/layouts/partials/slideout.html
+++ b/layouts/partials/slideout.html
@@ -11,7 +11,7 @@
 <nav id="mobile-menu" class="mobile-menu slideout-menu">
   <ul class="mobile-menu-list">
     {{ range .Site.Menus.main -}}
-      <a href="{{ .URL }}">
+      <a href="{{ .URL | safeURL }}">
         <li class="mobile-menu-item">{{ .Name }}</li>
       </a>
     {{- end }}


### PR DESCRIPTION
Adding ` | safeURL` allows the usage of "unsafe" url protocols such as `irc://` or `xmpp://`, see https://gohugo.io/functions/safeurl/ for details.

This will have no security impact because it can only be exploited by someone who already has full access to the page source and thereby full control over the generated page.

I also optimized the code and change the config sample to use a `mailto:` URI.