### PR TITLE
Fix rendering error introduced in #4

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,7 +6,7 @@
   <ul id="menu" class="menu">
     {{ range .Site.Menus.main -}}
       <li class="menu-item">
-        <a class="menu-item-link" href="{{ .URL | safeURL }}">{{ .Name }}</a>
+        <a class="menu-item-link" href="{{ .URL | safeURL }}">{{ .Name }}</a>
       </li>
     {{- end }}
   </ul>


### PR DESCRIPTION
For some odd reason there is a non-break space in 918ac9edb8cf7380aa48987db0e13d26339af908 which turns out to break hugo.

> ERROR 2017/09/14 17:52:02 theme/partials/header.html : template: theme/partials/header.html:8: unexpected unrecognized character in action: U+00A0 in command