### PR TITLE
fix: use `absURL` to be agnostic of `baseURL` used in config.toml

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Sitemap: {{ .Site.BaseURL }}sitemap.xml
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
This PR fixes issue #6 