### PR TITLE
增加 config file option 讓 mathiax 支援 $ inline 渲染

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -18,6 +18,7 @@ autoCollapseToc: false
 contentCopyright: false
 reward: false
 mathjax: false
+mathjaxEnableSingleDollar: false
 ---
 
 <!--more-->

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -67,7 +67,7 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   fancybox = true           # see https://github.com/fancyapps/fancybox                 # 是否启用fancybox（图片可点击）
   bootcdn = false           # In china. @Deprecated: use [params.publicCDN]             # 是否使用bootcdn(@Deprecated: 请使用[params.publicCDN])
   mathjax = false           # see https://www.mathjax.org/                              # 是否使用mathjax（数学公式）
-  mathjaxAddDelimiters = false                                                          # 是否使用 $$ 即可進行inline latex渲染
+  mathjaxEnableSingleDollar = false                                                     # 是否使用 $...$ 即可進行inline latex渲染
   linkToMarkDown = false    # if you config contentCopyright and hugo output .md files. # 是否在链接到markdown原始文件（如果你配置了下面的许可协议并允许hugo生成markdown文件）
 
   contentCopyright = '<a rel="license noopener" href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank">CC BY-NC-ND 4.0</a>'

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -67,7 +67,7 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   fancybox = true           # see https://github.com/fancyapps/fancybox                 # 是否启用fancybox（图片可点击）
   bootcdn = false           # In china. @Deprecated: use [params.publicCDN]             # 是否使用bootcdn(@Deprecated: 请使用[params.publicCDN])
   mathjax = false           # see https://www.mathjax.org/                              # 是否使用mathjax（数学公式）
-  mathjaxAddDelimiters = false
+  mathjaxAddDelimiters = false                                                          # 是否使用 $$ 即可進行inline latex渲染
   linkToMarkDown = false    # if you config contentCopyright and hugo output .md files. # 是否在链接到markdown原始文件（如果你配置了下面的许可协议并允许hugo生成markdown文件）
 
   contentCopyright = '<a rel="license noopener" href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank">CC BY-NC-ND 4.0</a>'

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -67,6 +67,7 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   fancybox = true           # see https://github.com/fancyapps/fancybox                 # 是否启用fancybox（图片可点击）
   bootcdn = false           # In china. @Deprecated: use [params.publicCDN]             # 是否使用bootcdn(@Deprecated: 请使用[params.publicCDN])
   mathjax = false           # see https://www.mathjax.org/                              # 是否使用mathjax（数学公式）
+  mathjaxAddDelimiters = false
   linkToMarkDown = false    # if you config contentCopyright and hugo output .md files. # 是否在链接到markdown原始文件（如果你配置了下面的许可协议并允许hugo生成markdown文件）
 
   contentCopyright = '<a rel="license noopener" href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank">CC BY-NC-ND 4.0</a>'

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -22,6 +22,15 @@
       messageStyle: 'none'
     };
   </script>
+
+  {{- if or .Params.mathjaxAddDelimiters .Site.Params.mathjaxAddDelimiters}}
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+    });
+    </script>
+  {{- end }}
+  
   <script async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'></script>
 {{- end }}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -16,21 +16,15 @@
 <script type="text/javascript" src="{{ "dist/even.min.js?v=2.7.2" | relURL }}"></script>
 
 {{- if and (or .Params.mathjax (and .Site.Params.mathjax (ne .Params.mathjax false))) (or .IsPage .IsHome) }}
-  <script type="text/javascript">
-    window.MathJax = {
+  <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+      {{ if or .Params.mathjaxEnableSingleDollar (and .Site.Params.mathjaxEnableSingleDollar (ne .Params.mathjaxEnableSingleDollar false)) -}}
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]},
+      {{ end -}}
       showProcessingMessages: false,
       messageStyle: 'none'
-    };
-  </script>
-
-  {{- if or .Params.mathjaxAddDelimiters .Site.Params.mathjaxAddDelimiters}}
-    <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
     });
-    </script>
-  {{- end }}
-  
+  </script>
   <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 {{- end }}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -31,7 +31,7 @@
     </script>
   {{- end }}
   
-  <script async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'></script>
+  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 {{- end }}
 
 <!-- Analytics -->


### PR DESCRIPTION
加入的代碼如[此文](https://docs.mathjax.org/en/latest/start.html#tex-and-latex-input)所提及
