### PR TITLE
Added option to hide header and footer for a post

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,9 +16,11 @@
 <body>
   {{ partial "slideout.html" . }}
   <div class="container" id="mobile-panel">
+    {{ if not .Params.hideHeaderAndFooter }}
     <header id="header" class="header">
         {{ partial "header.html" . }}
     </header>
+    {{ end }}
 
     <main id="main" class="main">
       <div class="content-wrapper">
@@ -29,9 +31,11 @@
       </div>
     </main>
 
+    {{ if not .Params.hideHeaderAndFooter }}
     <footer id="footer" class="footer">
       {{ partial "footer.html" . }}
     </footer>
+    {{ end }}
 
     <div class="back-to-top" id="back-to-top">
       <i class="iconfont icon-up"></i>


### PR DESCRIPTION
For pages that are unlisted I would also like the ability to hide the header and footer for direct linked posts. This PR adds a flag for posts that allows you to hide the header and the footer.