### PR TITLE
Fix hard coded section name

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,7 +1,7 @@
 {{ define "title" }}{{ T "archive" }} - {{ .Site.Title }}{{ end }}
 
 {{ define "content"}}
-{{- $paginator := .Paginate (where .Data.Pages.ByDate.Reverse "Type" "post") .Site.Params.archivePaginate }}
+{{- $paginator := .Paginate .Data.Pages.ByDate.Reverse .Site.Params.archivePaginate }}
 <section id="archive" class="archive">
   {{- if not $paginator.HasPrev }}
     <div class="archive-title">

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,7 +1,7 @@
 {{ define "title" }}{{ .Title }} · {{ .Site.Title }}{{ end }}
 
 {{ define "content"}}
-{{ $paginator := .Paginate (where .Data.Pages.ByDate.Reverse "Type" "post") .Site.Params.archivePaginate }}
+{{ $paginator := .Paginate .Data.Pages.ByDate.Reverse .Site.Params.archivePaginate }}
 <section id="archive" class="archive">
   {{ if not $paginator.HasPrev }}
     {{ if eq .Data.Plural "tags" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
   <section id="posts" class="posts">
     {{/* (index .Site.Paginate) */}}
-    {{ $paginator := .Paginate (where .Data.Pages ".Params.hiddenfromhomepage" "!=" true) }}
+    {{ $paginator := .Paginate (where (where .Data.Pages "Type" "post") ".Params.hiddenfromhomepage" "!=" true) }}
     {{ range $paginator.Pages }}
       {{ .Render "summary" }}
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "content" }}
   <section id="posts" class="posts">
     {{/* (index .Site.Paginate) */}}
-    {{ $paginator := .Paginate (where (where .Data.Pages "Type" "post") ".Params.hiddenfromhomepage" "!=" true) }}
+    {{ $paginator := .Paginate (where .Data.Pages ".Params.hiddenfromhomepage" "!=" true) }}
     {{ range $paginator.Pages }}
       {{ .Render "summary" }}
     {{ end }}


### PR DESCRIPTION
Resolve issue: https://github.com/olOwOlo/hugo-theme-even/issues/65

Fix empty article list problem when clicking into a tag/category that is not defined in the section named "post".

修复了由"post"以外的section里的文章定义的标签/分类，点进去无法展示文章列表的问题。