### PR TITLE
fix(config): MediaType's Suffix deprecated warning

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -186,7 +186,7 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
 # Uncomment these options to make hugo output .md files.
 #[mediaTypes]
 #  [mediaTypes."text/plain"]
-#    suffix = "md"
+#    suffixes = ["md"]
 #
 #[outputFormats.MarkDown]
 #  mediaType = "text/plain"


### PR DESCRIPTION
`MediaType.Suffix` has now been deprecated.

---

Fixes #99 