### PR TITLE
fix(busuanzi): update busuanzi address

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -57,7 +57,7 @@
 
 <!-- busuanzi -->
 {{ if .Site.Params.busuanzi.enable -}}
-<script async src="//dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js"></script>
+<script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 {{- end }}
 
 <!-- Styles -->


### PR DESCRIPTION
update busuanzi domain address.

> 因七牛强制过期原有的『dn-lbstatics.qbox.me』域名（预计2018年10月初），与客服沟通数次无果，即使我提出为此付费也不行，只能更换域名到『busuanzi.ibruce.info』！

- [不蒜子作者通告](http://ibruce.info/)