### PR TITLE
uglyurls with tag and categories terms

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -105,6 +105,8 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   customCSS = []
   customJS = []
 
+  uglyURLs = false          # please keep same with uglyurls setting
+
   [params.publicCDN]        # load these files from public cdn                          # 启用公共CDN，需自行定义
     enable = true
     jquery = '<script src="https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>'

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -15,7 +15,7 @@
       </div>
       <div class="terms-tags">
         {{ range $key, $value := $terms -}}
-          <a class="terms-link" href="{{ $name | relLangURL }}/{{ $value.Term | urlize }}/">
+          <a class="terms-link" href="{{ $name | relLangURL }}/{{ $value.Term | urlize }}{{ if $.Site.Params.uglyURLs }}.html{{else}}/{{ end }}">
             {{ $value.Term }}
             <span class="terms-count">{{ len $value.Pages }}</span>
           </a>
@@ -33,7 +33,7 @@
       </div>
       <div class="terms-tags">
         {{- range $key, $value := $terms }}
-          <a class="terms-link" href="{{ $name | relLangURL }}/{{ $value.Term | urlize }}/">
+          <a class="terms-link" href="{{ $name | relLangURL }}/{{ $value.Term | urlize }}{{ if $.Site.Params.uglyURLs }}.html{{else}}/{{ end }}">
             {{ $value.Term }}
             <span class="terms-count">{{ len $value.Pages }}</span>
           </a>


### PR DESCRIPTION
在设置里使用 uglyurl = true，即使用类 `/post/note.html` 的 url 的时候，tag 和 catalog 页面下的 term? 的
 url 还是原来的样式。gohugoio/hugo#1989 ，但是 hugo 作者好像没有给出在模板里获取 uglyurl 配置的方法，就只能在 `params.uglyURLs`  里冗余一份。也有可能有更好的方式，还请多多指教。