### PR TITLE
feat(comment): add utterances support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -136,6 +136,10 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
     clientId = ""           # Your client ID
     clientSecret = ""       # Your client secret
 
+  [params.utterances]       # https://utteranc.es/
+    owner = ""              # Your GitHub ID
+    repo = ""               # The repo to store comments
+
   [params.gitalk]           # Gitalk is a comment system based on GitHub issues. see https://github.com/gitalk/gitalk
     owner = ""              # Your GitHub ID
     repo = ""               # The repo to store comments

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -96,4 +96,16 @@
     <noscript>Please enable JavaScript to view the <a href="https://github.com/gitalk/gitalk">comments powered by gitalk.</a></noscript>
   {{- end }}
 
+  <!-- utterances -->
+  {{- if .Site.Params.utterances.owner}}
+    <script src="https://utteranc.es/client.js"
+            repo="{{ .Site.Params.utterances.owner }}/{{ .Site.Params.utterances.repo }}"
+            issue-term="pathname"
+            theme="github-light"
+            crossorigin="anonymous"
+            async>
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="https://github.com/utterance">comments powered by utterances.</a></noscript>
+  {{- end }}
+
 {{- end }}


### PR DESCRIPTION
## Feature Description

add [utterances](https://utteranc.es/) comment support

See the Issue https://github.com/olOwOlo/hugo-theme-even/issues/117

## Preview

You can preview the utterances comments in my blog: https://www.bwangel.me/about/