### PR TITLE
fix(layouts/partials/head.html): fix hugo 0.55 warning

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,7 +33,7 @@
 {{ with .Site.Params.googleVerification }}<meta name="google-site-verification" content="{{.}}" />{{ end }}
 
 <!-- Site Generator -->
-<meta name="generator" content="Hugo {{ .Hugo.Version }} with even 4.0.0" />
+<meta name="generator" content="Hugo {{ .Site.Hugo.Version }} with even 4.0.0" />
 
 <!-- Permalink & RSSlink -->
 <link rel="canonical" href="{{ .Permalink }}" />


### PR DESCRIPTION
fix  hugo 0.55 warning **Building sites … WARN 2019/04/27 16:35:25 Page's .Hugo is deprecated and will be removed in a future
release. Use the global hugo function.**

issue https://github.com/olOwOlo/hugo-theme-even/issues/158