### PR TITLE
Fix hugo rsslink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,7 +33,7 @@
 {{ with .Site.Params.googleVerification }}<meta name="google-site-verification" content="{{.}}" />{{ end }}
 
 <!-- Site Generator -->
-<meta name="generator" content="Hugo {{ .Hugo.Version }} with even 4.0.0" />
+<meta name="generator" content="Hugo {{ .Site.Hugo.Version }} with even 4.0.0" />
 
 <!-- Permalink & RSSlink -->
 <link rel="canonical" href="{{ .Permalink }}" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,9 +37,9 @@
 
 <!-- Permalink & RSSlink -->
 <link rel="canonical" href="{{ .Permalink }}" />
-{{- if .RSSLink }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+{{- if .RelPermalink }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{- end -}}
 
 <!-- Favicon and Touch icons -->


### PR DESCRIPTION
fix hugo 0.55 warning **WARN 2019/04/27 16:36:55 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.**

我的博客使用的是这个主题, hugo 版本是 0.55.3
覆盖掉主题的 layouts/partials/head.html 文件，就没有警告了
博客地址 https://github.com/nusr/blog