### PR TITLE
feat: support diff highlight

### DIFF
--- a/src/css/_partial/_post/_code.scss
+++ b/src/css/_partial/_post/_code.scss
@@ -270,11 +270,11 @@ figure.highlight {
   /* CommentPreproc */  .cp { color: #93a1a1; font-style: italic }
   /* CommentPreprocFile */  .cpf { color: #93a1a1; font-style: italic }
   /* Generic */  .g { color: #d33682 }
-  /* GenericDeleted */  .gd { color: #d33682 }
+  /* GenericDeleted */  .gd { color: #b58900 }
   /* GenericEmph */  .ge { color: #d33682 }
   /* GenericError */  .gr { color: #d33682 }
   /* GenericHeading */  .gh { color: #d33682 }
-  /* GenericInserted */  .gi { color: #d33682 }
+  /* GenericInserted */  .gi { color: #859900 }
   /* GenericOutput */  .go { color: #d33682 }
   /* GenericPrompt */  .gp { color: #d33682 }
   /* GenericStrong */  .gs { color: #d33682 }

--- a/src/css/_variables.scss
+++ b/src/css/_variables.scss
@@ -252,7 +252,8 @@ $code-type-list: (
   language-typescript: "TypeScript",
   language-yml: "YAML",
   language-yaml: "YAML",
-  language-toml: "TOML"
+  language-toml: "TOML",
+  language-diff: "Diff"
 ) !default;
 
 // Color of the code background.


### PR DESCRIPTION
This PR is trying to support diff highlight, so that you can write diff code in code block:

```text

```diff
+ this is inserted line.
- this is modified line.
```

```


The color is from https://github.com/braver/Solarized/blob/master/Solarized%20(light).sublime-color-scheme