### PR TITLE
兼容ox-hugo生成的author属性格式（[]string）

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,7 +10,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="#f8f5ec">
 
 <!-- author & description & keywords  -->
-<meta name="author" content="{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}" />
+<meta name="author" content="{{ if .Params.author }}{{ with .Params.author }}{{ $author_type := (printf "%T" .) }}{{ $author_is_slice := (eq "[]string" $author_type) }}{{ if $author_is_slice }}{{ delimit . ", " | safeHTML }}{{ else }}{{ . | safeHTML}}{{ end }}{{ end }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}" />
 
 {{- if .Description -}}
   <meta name="description" content="{{ .Description | safeHTML }}" />

--- a/layouts/partials/post/copyright.html
+++ b/layouts/partials/post/copyright.html
@@ -2,7 +2,7 @@
 <div class="post-copyright">
   <p class="copyright-item">
     <span class="item-title">{{ T "author" }}</span>
-    <span class="item-content">{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}</span>
+    <span class="item-content">{{ if .Params.author }}{{ with .Params.author  }}{{ $author_type := (printf "%T" .)  }}{{ $author_is_slice := (eq "[]string" $author_type)  }}{{ if $author_is_slice  }}{{ delimit . ", " | safeHTML  }}{{ else  }}{{ . | safeHTML }}{{ end  }}{{ end  }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}</span>
   </p>
   <p class="copyright-item">
     <span class="item-title">{{ T "lastMod" }}</span>


### PR DESCRIPTION
使用ox-hugo从org文件导出到md文件时，org文件中的`:author:`属性会生成为`author = [XXXXX]`的格式，此时在even主题中就会出现渲染错误，查阅ox-hugo文档，给出了解决方案。

此修改增加了对author属性的判断，兼容正常的string类型以及ox-hugo导出的[]string列表类型。