### PR TITLE
Infinity scrolling post on the Chrome and Safari

### DIFF
--- a/src/css/_partial/_post/_content.scss
+++ b/src/css/_partial/_post/_content.scss
@@ -23,6 +23,7 @@
         .icon-link {
           visibility: hidden;
           font-size: 16px;
+          display: contents;
 
           &:before {
             vertical-align: middle;


### PR DESCRIPTION
Related Issue.
- [ISSUE#209](https://github.com/olOwOlo/hugo-theme-even/issues/209)
- [ISSUE#223](https://github.com/olOwOlo/hugo-theme-even/issues/223)

The CSS was modified to restore the location of the icon (.post-content h1 .anchor .icon-link).
So, there is no infinite scroll of a post in Chrome and Safari anymore.
![image](https://user-images.githubusercontent.com/36671804/72218248-54043480-357c-11ea-974b-764058d4e4b4.png)