### PR TITLE
feat(*): use markdown render hook for images and links

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}"{{ end }}/>
+  <figcaption><h4>{{ with .Title}} {{ . }} {{ end }}</h4></figcaption>
+</figure>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}" target="_blank" rel="noopener">{{ .Text }}</a>


### PR DESCRIPTION
[Render hooks](https://gohugo.io/getting-started/configuration-markup/#render-hook-templates) is introduced by Hugo 0.62.0.

Resolves #228 