### PR TITLE
feat(scripts): only enable google analytics in production environment

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -93,7 +93,7 @@
 {{- end }}
 
 <!-- Analytics -->
-{{- if and (not .Site.IsServer) .Site.GoogleAnalytics -}}
+{{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and .Site.GoogleAnalytics -}}
   {{ template "_internal/google_analytics_async.html" . }}
 {{- end -}}
 


### PR DESCRIPTION
Should set env to production, e.g.: `hugo serve -e production`

Default environments are **development** with `hugo serve` and **production** with `hugo`.

Closes #259 