### PR TITLE
add config option to hide the summary from posts

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -75,6 +75,9 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   # show word count and read time ?                       # 是否显示字数统计与阅读时间
   moreMeta = false
 
+  # hide summary in home page                             # 首页是否隐藏 summary
+  hideSummary = false
+
   # Syntax highlighting by highlight.js
   highlightInClient = false
 

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -1,5 +1,9 @@
 <article class="post">
+  {{- if .Site.Params.hideSummary }}
+  <header class="post-header no-padding">
+  {{- else -}}
   <header class="post-header">
+  {{- end }}
     <h1 class="post-title"><a class="post-link" href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
     <div class="post-meta">
       <span class="post-time"> {{ .Date.Format (.Site.Params.dateFormatToUse | default "2006-01-02") }} </span>
@@ -17,6 +21,7 @@
     </div>
   </header>
   <!-- Content -->
+  {{- if not .Site.Params.hideSummary }}
   <div class="post-content">
     <div class="post-summary">
       {{ .Summary }}
@@ -25,4 +30,5 @@
       <a href="{{ .RelPermalink }}" class="read-more-link">{{ T "readMore" }}</a>
     </div>
   </div>
+  {{- end }}
 </article>


### PR DESCRIPTION
This change is part of another fork here at github and I think this
would be great to see merged into upstream sources.

best regards,

Florian La Roche
