### PR TITLE
fix js toc error

### DIFF
--- a/assets/js/even.js
+++ b/assets/js/even.js
@@ -113,7 +113,7 @@ Even._initToc = function() {
     $($toclink).removeClass('active');
     $($tocLinkLis).removeClass('has-active');
 
-    if (activeTocIndex !== -1) {
+    if (activeTocIndex !== -1 && $toclink[activeTocIndex] != null) {
       $($toclink[activeTocIndex]).addClass('active');
       let ancestor = $toclink[activeTocIndex].parentNode;
       while (ancestor.tagName !== 'NAV') {


### PR DESCRIPTION
fix `let ancestor = $toclink[activeTocIndex].parentNode;`  `Uncaught TypeError: Cannot read property 'parentNode' of undefined` error

`const $toclink = $('.toc-link');` 
only support h1 h2 h3 in markdown syntax, but `const $headerlink = $('.headerlink');` can support h4 h5 ...
if .md file contains h4 h5 headers ... `$toclink[activeTocIndex]`  activeTocIndex out of range, equals null