### PR TITLE
Enable showing full content in archive / front pages

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -66,6 +66,9 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
   # paginate of archives, tags and categories             # 归档、标签、分类每页显示的文章数目，建议修改为一个较大的值
   archivePaginate = 5
 
+  # Display full content of posts or just summaries in archive / front pages
+  fullContent = false
+
   # show 'xx Posts In Total' in archive page ?            # 是否在归档页显示文章的总数
   showArchiveCount = false
 

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -18,11 +18,15 @@
   </header>
   <!-- Content -->
   <div class="post-content">
-    <div class="post-summary">
-      {{ .Summary }}
-    </div>
-    <div class="read-more">
-      <a href="{{ .RelPermalink }}" class="read-more-link">{{ T "readMore" }}</a>
-    </div>
+    {{- if .Site.Params.fullContent }}
+      {{ .Content }}
+    {{- else }}
+      <div class="post-summary">
+        {{ .Summary }}
+      </div>
+      <div class="read-more">
+        <a href="{{ .RelPermalink }}" class="read-more-link">{{ T "readMore" }}</a>
+      </div>
+    {{- end }}
   </div>
 </article>


### PR DESCRIPTION
For my blog, I want to show the full content of each post
on the front page and on archive pages. Currently, there
is no way to do that with this (awesome!) theme. This patch
adds a setting (defaults to false to preserve current behavior)
to toggle this behavior.