### PR TITLE
fix(scss): Fix code block padding with `codeFences = false`

### DIFF
--- a/assets/sass/_partial/_post/_code.scss
+++ b/assets/sass/_partial/_post/_code.scss
@@ -11,6 +11,10 @@ code {
   color: $code-color;
 }
 
+pre > code {
+  display: block;
+}
+
 // highlight.js
 figure.highlight {
   margin: 1em 0;
@@ -129,11 +133,11 @@ figure.highlight {
     .hljs-formula {
       background: map-get($code-highlight-color, formula);
     }
-    
+
     .hljs-emphasis {
       font-style: italic;
     }
-    
+
     .hljs-strong {
       font-weight: bold;
     }


### PR DESCRIPTION
When code fences are disabled (to have nice small code snippets)
```
[markup]
  [markup.highlight]
    codeFences = false
```

Before:
<img width="835" alt="Screen Shot 2020-07-25 at 11 47 55" src="https://user-images.githubusercontent.com/335778/88453278-2f174500-ce6e-11ea-8de2-fcfce09c81b1.png">

Now:
<img width="805" alt="Screen Shot 2020-07-25 at 11 57 02" src="https://user-images.githubusercontent.com/335778/88453287-376f8000-ce6e-11ea-908b-fa17e36c07ea.png">