### PR TITLE
fix: Allow theme-color-config to be overridden

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -5,7 +5,7 @@
 // ========== Theme Color ========== //
 // Config here to change theme color
 // Default | Mint Green | Cobalt Blue | Hot Pink | Dark Violet
-$theme-color-config: 'Default';
+$theme-color-config: 'Default' !default;
 
 // Default theme color map
 $theme-color-map: (


### PR DESCRIPTION
This sets the default flag for the `theme-color-config` variable so it can be overridden in `_custom.scss`.

This in combination with Hugo mounts[1] allows you to change the theme color without needing to modify the theme directly.

[1]
```
module:
  mounts:
  - source: static/css/color-config.scss   
    target: assets/sass/_custom/_custom.scss
```

Signed-off-by: Brad Beam <brad.beam@b-rad.info>