### PR TITLE
fix(uglyurls): fix the path of tags in the case of uglyURLs = true.

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -45,7 +45,7 @@
       {{ with .Params.tags -}}
         <div class="post-tags">
           {{ range . -}}
-            <a href="{{ "tags" | relLangURL }}/{{ . | urlize }}/">{{ . }}</a>
+            <a href="{{ "tags" | relLangURL }}/{{ . | urlize }}{{ if $.Site.Params.uglyURLs }}.html{{ else }}/{{ end }}">{{ . }}</a>
           {{ end -}}
         </div>
       {{- end -}}


### PR DESCRIPTION
### config.toml

```toml
uglyURLs = true
[params] 
  uglyURLs = true
```

### before

```shell
$ curl -s http://localhost:1313/post/even-preview.html | grep "/tags/preview"
          <a href="/tags/preview/">preview</a>
```

### now

```shell
$ curl -s http://localhost:1313/post/even-preview.html | grep "/tags/preview"
          <a href="/tags/preview.html">preview</a>
```