### PR TITLE
fix 当无header时fancybox失效

### DIFF
--- a/assets/js/even.js
+++ b/assets/js/even.js
@@ -181,8 +181,7 @@ Even.toc = function() {
   const tocContainer = document.getElementById('post-toc');
   if (tocContainer !== null) {
     const toc = document.getElementById('TableOfContents');
-    if (toc === null) {
-      // toc = true, but there are no headings
+    if (toc == null || !toc.hasChildNodes()) {
       tocContainer.parentNode.removeChild(tocContainer);
     } else {
       this._refactorToc(toc);


### PR DESCRIPTION
如果文章里没有header，那么，图片也不会施加fancybox，同时console报错：

```js
jquery.min.js:2 Uncaught TypeError: Cannot read property 'children' of undefined
    at Object.Even._refactorToc (main.min.c12618f9a600c40bd024996677e951e64d3487006775aeb22e200c990006c5c7.js:5)
    at Object.Even.toc (main.min.c12618f9a600c40bd024996677e951e64d3487006775aeb22e200c990006c5c7.js:5)
    at HTMLDocument.<anonymous> (main.min.c12618f9a600c40bd024996677e951e64d3487006775aeb22e200c990006c5c7.js:6)
    at j (jquery.min.js:2)
    at k (jquery.min.js:2)
```

这是因为当无header时，`toc`的值为`<nav id="TableOfContents"></nav>`，而不是`null`。

```js
const toc = document.getElementById('TableOfContents');
if (toc === null) {
    // toc = true, but there are no headings
    tocContainer.parentNode.removeChild(tocContainer);
}
```