### PR TITLE
fix(scss): make $theme-color-config writable from user's custom scss file

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -5,7 +5,7 @@
 // ========== Theme Color ========== //
 // Config here to change theme color
 // Default | Mint Green | Cobalt Blue | Hot Pink | Dark Violet
-$theme-color-config: 'Default';
+$theme-color-config: 'Default' !default;
 
 // Default theme color map
 $theme-color-map: (


### PR DESCRIPTION
By adding the !default flag as well as $global-font-family, etc., we allow $theme-color-config to be writable from the user's custom scss file.