### PR TITLE
fix: support google analytic v4

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -94,6 +94,7 @@
 
 <!-- Analytics -->
 {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and .Site.GoogleAnalytics -}}
+  {{ template "_internal/google_analytics.html" . }}
   {{ template "_internal/google_analytics_async.html" . }}
 {{- end -}}
 


### PR DESCRIPTION
use googleAnalytics in “G-”ID will not send to google Analytics

as i check the hugo source code,the bug is not in hugo,and hugo support v4 version now.
and i find even is use google_analytics_async template now, in hugo this template is not support v4,so need and this line.

![image](https://user-images.githubusercontent.com/34479567/118986458-f83c8d80-b9b1-11eb-960a-d86530e37e80.png)
