### PR TITLE
Translate Lastmod to Updated

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -71,7 +71,7 @@ author:
   other: "Author"
 
 lastMod:
-  other: "LastMod"
+  other: "Changed"
 
 markdown:
   other: "Markdown"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -71,7 +71,7 @@ author:
   other: "Author"
 
 lastMod:
-  other: "Changed"
+  other: "Updated"
 
 markdown:
   other: "Markdown"


### PR DESCRIPTION
Lastmod is not an English word. It is not intuitive for those unfamiliar with Hugo terminology. 

I propose changing it to `Updated` instead, as it is actually the date of the last update.