### PR TITLE
Removed reference to deprecated google_news internal template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -76,7 +76,6 @@
 
 {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/spf13/hugo/blob/master/tpl/tplimpl/template_embedded.go#L158 */}}
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
Removed reference google_news internal template as it's deprecated https://github.com/gohugoio/hugo/issues/9172

Deprecation warning:
```
hugo v0.91.2+extended: The google_news internal template will be removed in a future release. Please remove calls to this template. See https://github.com/gohugoio/hugo/issues/9172 for additional information.
```