### PR TITLE
support google analytics 4

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -52,7 +52,7 @@ $global-body-width: 800px !default;
 $global-container-padding: 0 20px !default;
 
 // Default line height for all type. `$global-lineheight` is 24px while `$global-font-size` is 16px.
-$global-lineheight: 1.5 !default;
+$global-lineheight: 2.0 !default;
 
 // Font family of the site.
 $global-font-family: 'Source Sans Pro', 'Helvetica Neue', Arial, sans-serif !default;

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -94,7 +94,7 @@
 
 <!-- Analytics -->
 {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and .Site.GoogleAnalytics -}}
-  {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
 {{- end -}}
 
 {{- with .Site.Params.baiduAnalytics -}}


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

Hugo had officially supported Google Analytics 4 at v0.82.0,https://github.com/gohugoio/hugo/commit/ba16a14c6e884e309380610331aff78213f84751.

This PR would let hugo-theme-even use updated template.