### PR TITLE
Add support for GA4

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,6 +31,8 @@
       </div>
     </main>
 
+    {{ template "_internal/google_analytics.html" . }}
+
     {{ if not .Params.hideHeaderAndFooter -}}
     <footer id="footer" class="footer">
       {{ partial "footer.html" . }}


### PR DESCRIPTION
GA4 support added for Hugo internal templates officially - h[ttps://gohugo.io/templates/internal/#google-analytics](url)

Modified layouts/_default/baseof.html to support GA4 officially.

