### PR TITLE
fix:render failed since hugo v0.111.0

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -74,9 +74,8 @@
 <link rel="stylesheet" href="{{ "/css/" | relURL }}{{ . }}">
 {{ end }}
 
-{{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/spf13/hugo/blob/master/tpl/tplimpl/template_embedded.go#L158 */}}
+{{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/gohugoio/hugo/tree/master/tpl/tplimpl/embedded/templates */}}
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
Since version v0.111.0 of Hugo (https://github.com/gohugoio/hugo/commit/66f94b4945e804f10be0a04d1365bb3c6e1a4c05), the Google News template has been removed, which causes theme rendering to fail.

```
(base) ➜  uucloud git:(master) ✗ hugo
Start building sites …
hugo v0.111.3+extended darwin/amd64 BuildDate=unknown
ERROR 2023/03/20 19:42:45 render of "page" failed: "/Users/dyp/blog/hugo/uucloud/themes/even/layouts/_default/baseof.html:14:5": execute of template failed: template: post/single.html:14:5: executing "post/single.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:79:13: no such template "_internal/google_news.html"
ERROR 2023/03/20 19:42:45 render of "section" failed: "/Users/dyp/blog/hugo/uucloud/themes/even/layouts/_default/baseof.html:14:5": execute of template failed: template: _default/section.html:14:5: executing "_default/section.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:79:13: no such template "_internal/google_news.html"
ERROR 2023/03/20 19:42:45 render of "taxonomy" failed: "/Users/dyp/blog/hugo/uucloud/themes/even/layouts/_default/baseof.html:14:5": execute of template failed: template: _default/terms.html:14:5: executing "_default/terms.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:79:13: no such template "_internal/google_news.html"
ERROR 2023/03/20 19:42:45 render of "home" failed: "/Users/dyp/blog/hugo/uucloud/themes/even/layouts/_default/baseof.html:14:5": execute of template failed: template: index.html:14:5: executing "index.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:79:13: no such template "_internal/google_news.html"
Error: Error building site: failed to render pages: render of "page" failed: "/Users/dyp/blog/hugo/uucloud/themes/even/layouts/_default/baseof.html:14:5": execute of template failed: template: _default/single.html:14:5: executing "_default/single.html" at <partial "head.html" .>: error calling partial: execute of template failed: html/template:partials/head.html:79:13: no such template "_internal/google_news.html"
Total in 128 ms
```