### PR TITLE
Update head.html to remove deprecated template from Hugo

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -76,7 +76,6 @@
 
 {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/spf13/hugo/blob/master/tpl/tplimpl/template_embedded.go#L158 */}}
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
Fix issue #429. Tested locally.
