### PR TITLE
fix(analytics): support GA4

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -94,7 +94,7 @@
 
 <!-- Analytics -->
 {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and .Site.GoogleAnalytics -}}
-  {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
 {{- end -}}
 
 {{- with .Site.Params.baiduAnalytics -}}


### PR DESCRIPTION
in recent hugo versions GA4 is supported by including: `_internal/google_analytics.html" ` (https://gohugo.io/templates/embedded/#google-analytics)