### PR TITLE
fix .Site.RSSLink was deprecated in Hugo v0.114.0

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
   {{ if .Site.LanguagePrefix -}}
     <a href="{{ .Site.LanguagePrefix | absURL }}/index.xml" type="application/rss+xml" class="iconfont icon-rss" title="rss"></a>
   {{- else -}}
-    <a href="{{ .Site.RSSLink }}" type="application/rss+xml" class="iconfont icon-rss" title="rss"></a>
+    <a href="{{ .Permalink}}" type="application/rss+xml" class="iconfont icon-rss" title="rss"></a>
   {{- end }}
 </div>
 


### PR DESCRIPTION
Fix error when runing this theme in hugo, which verion is v0.127.0


hugo v0.127.0+extended darwin/arm64 BuildDate=2024-06-05T10:27:59Z VendorInfo=brew

ERROR deprecated: .Site.RSSLink was deprecated in Hugo v0.114.0 and will be removed in Hugo 0.128.0. Use the Output Format's Permalink method instead, e.g. .OutputFormats.Get "RSS".Permalink
WARN deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.GoogleAnalytics.ID instead.
WARN deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
WARN The author key in site configuration is deprecated. Use params.author.name instead.
Built in 53 ms
Error: error building site: logged 1 error(s)