### PR TITLE
fix: Compatible with the latest version of Hugo.

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,6 +1,6 @@
 {{ if and .IsPage (ne .Params.comment false) -}}
   <!-- Disqus -->
-  {{- if .Site.DisqusShortname -}}
+  {{- if .Site.Config.Services.Disqus.Shortname -}}
     <div id="disqus_thread"></div>
     <script type="text/javascript">
     (function() {
@@ -9,7 +9,7 @@
       if (window.location.hostname === 'localhost') return;
 
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      var disqus_shortname = '{{ .Site.DisqusShortname }}';
+      var disqus_shortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
       dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,9 @@
   {{ if .Site.LanguagePrefix -}}
     <a href="{{ .Site.LanguagePrefix | absURL }}/index.xml" type="application/rss+xml" class="iconfont icon-rss" title="rss"></a>
   {{- else -}}
-    <a href="{{ .Site.RSSLink }}" type="application/rss+xml" class="iconfont icon-rss" title="rss"></a>
+  {{ with .OutputFormats.Get "RSS" }}
+    <a href="{{ .RelPermalink }}" type="application/rss+xml" class="iconfont icon-rss" title="rss"></a>
+  {{ end }}
   {{- end }}
 </div>
 
@@ -45,6 +47,6 @@
     {{ end }}
     {{- $current -}}
     <span class="heart"><i class="iconfont icon-heart"></i></span><!--
-    --><span>{{if .Site.Copyright }}{{ .Site.Copyright | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}</span>
+    --><span>{{if .Site.Copyright }}{{ .Site.Copyright | safeHTML }}{{ else }}{{ .Site.Params.Author.name | safeHTML }}{{ end }}</span>
   </span>
 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,7 +10,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="#f8f5ec">
 
 <!-- author & description & keywords  -->
-<meta name="author" content="{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}" />
+<meta name="author" content="{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Params.Author.name | safeHTML }}{{ end }}" />
 
 {{- if .Description -}}
   <meta name="description" content="{{ .Description | safeHTML }}" />

--- a/layouts/partials/header/language-selector.html
+++ b/layouts/partials/header/language-selector.html
@@ -5,7 +5,7 @@
   to the translated page. If not, the link will be to the home page of the site
   with specified language.
 -->
-{{ if (and (.Site.IsMultiLingual) ($.Site.Params.showLanguageSelector)) }}
+{{ if (and (hugo.IsMultilingual) ($.Site.Params.showLanguageSelector)) }}
   <div class="language-selector">
     <ul class="languages-list">
       {{ range $homeTranslation := .Site.Home.AllTranslations }}

--- a/layouts/partials/post/copyright.html
+++ b/layouts/partials/post/copyright.html
@@ -2,7 +2,7 @@
 <div class="post-copyright">
   <p class="copyright-item">
     <span class="item-title">{{ T "author" }}</span>
-    <span class="item-content">{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Author.name | safeHTML }}{{ end }}</span>
+    <span class="item-content">{{ if .Params.author }}{{ .Params.author | safeHTML }}{{ else }}{{ .Site.Params.Author.name | safeHTML }}{{ end }}</span>
   </p>
   <p class="copyright-item">
     <span class="item-title">{{ T "lastMod" }}</span>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -93,7 +93,7 @@
 {{- end }}
 
 <!-- Analytics -->
-{{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and .Site.GoogleAnalytics -}}
+{{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and .Site.Config.Services.GoogleAnalytics.ID -}}
   {{ template "_internal/google_analytics.html" . }}
 {{- end -}}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   HUGO_THEME = "repo"
   HUGO_THEMESDIR = "/opt/build"
-  HUGO_VERSION = "0.74.3"
+  HUGO_VERSION = "0.136.5"
 
 [context.production.environment]
   HUGO_BASEURL = "https://hugo-theme-even.netlify.app/"


### PR DESCRIPTION
In hugo v0.120.0 and higher version, some keyword is deprecated, like this one,
<img width="934" alt="image" src="https://github.com/user-attachments/assets/c0a70126-13ba-490f-a030-94cbace0efb6">
This pr is process this issue.