### PR TITLE
fix: code highlight

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,12 +8,6 @@ enableEmoji = true
 theme = "even"
 enableGitInfo = false # use git commit log to generate lastmod record # 可根据 Git 中的提交生成最近更新记录。
 
-# Syntax highlighting by Chroma. NOTE: Don't enable `highlightInClient` and `chroma` at the same time!
-pygmentsOptions = "linenos=table"
-pygmentsCodefences = true
-pygmentsUseClasses = true
-pygmentsCodefencesGuessSyntax = true
-
 hasCJKLanguage = true     # has chinese/japanese/korean ? # 自动检测是否包含 中文\日文\韩文
 paginate = 5                                              # 首页每页显示的文章数
 disqusShortname = ""      # disqus_shortname
@@ -207,10 +201,17 @@ copyright = ""            # default: author.name ↓        # 默认为下面配
 
 # see https://gohugo.io/getting-started/configuration-markup
 [markup]
-  [markup.tableOfContents]
-    startLevel = 1
-  [markup.goldmark.renderer]
-    unsafe = true
+  [markup.highlight]
+    codeFences = true
+    guessSyntax = true
+    lineNos = true
+    lineNumbersInTable = true
+    noClasses = false
+    tabWidth = 4
+    style = "monokai"
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
 
 # 将下面这段配置取消注释可以使 hugo 生成 .md 文件
 # Uncomment these options to make hugo output .md files.


### PR DESCRIPTION
Hey !

I noticed the code highlight was buggy since a recent version of Hugo.

It seems this PR would fix the issue.

There are probably more adjustments on the toml we could make.

https://gohugo.io/getting-started/configuration-markup/#highlight
